### PR TITLE
Fix misprint error in 3-wrapper.js

### DIFF
--- a/Solutions/3-wrapper.js
+++ b/Solutions/3-wrapper.js
@@ -10,7 +10,7 @@ const contract = (fn, ...types) => (...args) => {
     }
   }
   const res = fn(...args);
-  const def = types[args.length - 1];
+  const def = types[types.length - 1];
   const name = def.name.toLowerCase();
   if (typeof res !== name) {
     throw new TypeError(`Result type ${name} expected`);


### PR DESCRIPTION
Перевірка типу результату(`res`) працювала некоректно. `typeof res` порівнювався з передостаннім заданим елементом `types`, а не останнім, який передбачує очікуваний тип результату.